### PR TITLE
Add license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,6 @@
     "gulp-sass": "^2.3.2",
     "openurl": "^1.1.1",
     "preprocess": "^3.0.2"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
This pull request get rid of the warning you get when running `npm install`.

```
npm WARN oryoki@0.0.3 No license field.
```
