### PR TITLE
Hide status on hover

### DIFF
--- a/app/data/oryoki-preferences.json
+++ b/app/data/oryoki-preferences.json
@@ -6,7 +6,7 @@
 //
 {
 	// Do not touch!
-	"model_version" : "0.2.0",
+	"model_version" : "0.2.1",
 
 	// Allows Oryoki to download updates in background
 	"download_updates_in_background" : false,
@@ -53,7 +53,9 @@
 
 	// Hide the status bar
 	"hide_status_while_recording" : true,
-	"hide_status_on_hover" : false,
+
+	// Show the URL in the status bar on hover
+	"show_url_preview" : true,
 
 	// h264 | prores
 	// mp4 is light and lossy

--- a/app/data/oryoki-preferences.json
+++ b/app/data/oryoki-preferences.json
@@ -50,9 +50,10 @@
 	// Set a custom download path (absolute) here
 	// If left blank, will use the user's Downloads folder
 	"download_path" : "",
-	
-	// Hide the status bar when recording
+
+	// Hide the status bar
 	"hide_status_while_recording" : true,
+  "hide_status_on_hover" : false,
 
 	// h264 | prores
 	// mp4 is light and lossy

--- a/app/data/oryoki-preferences.json
+++ b/app/data/oryoki-preferences.json
@@ -53,7 +53,7 @@
 
 	// Hide the status bar
 	"hide_status_while_recording" : true,
-  "hide_status_on_hover" : false,
+	"hide_status_on_hover" : false,
 
 	// h264 | prores
 	// mp4 is light and lossy

--- a/app/windows.js
+++ b/app/windows.js
@@ -117,8 +117,6 @@ function create (url, target) {
       })
     }
   })
-
-  win.webContents.openDevTools()
 }
 
 function broadcast (data) {

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -52,7 +52,7 @@ function attachEvents () {
     rpc.emit('view:title-updated', e.title)
   })
   webview.addEventListener('update-target-url', (e) => {
-    if (config.getPreference('hide_status_on_hover') !== false) {
+    if (config.getPreference('show_url_preview')) {
       if (e.url !== '') rpc.emit('status:url-hover', e.url)
       if (e.url === '') rpc.emit('status:url-out')
     }

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -52,8 +52,10 @@ function attachEvents () {
     rpc.emit('view:title-updated', e.title)
   })
   webview.addEventListener('update-target-url', (e) => {
-    if (e.url !== '') rpc.emit('status:url-hover', e.url)
-    if (e.url === '') rpc.emit('status:url-out')
+    if (config.getPreference('hide_status_on_hover') !== false) {
+      if (e.url !== '') rpc.emit('status:url-hover', e.url)
+      if (e.url === '') rpc.emit('status:url-out')
+    }
   })
   webview.addEventListener('ipc-message', (e) => {
     if (e.channel !== 'webview:data') return


### PR DESCRIPTION
This enables a preference to be hide the status when hovering over links. Alternatively, this could check to see if the `href` is linking to another domain, and if so display the status, otherwise hide.

Personally find this fading in and out frequently to be a distraction. On mobile, where you don’t have hover states, this functionality doesn’t exist, and doesn’t feel like a security risk.

Side note, I tried adding a comment to the `preferences.json` consistent with the established formatting convention (`//`), but it throws an error about malformed JSON. Weird!