### PR TITLE
Request Mobile Site preference

### DIFF
--- a/app/data/oryoki-preferences.json
+++ b/app/data/oryoki-preferences.json
@@ -57,6 +57,9 @@
 	// Show the URL in the status bar on hover
 	"show_url_preview" : true,
 
+	// Request mobile sites
+	"request_mobile_site": false,
+
 	// h264 | prores
 	// mp4 is light and lossy
 	// prores is big and lossless

--- a/app/menus.js
+++ b/app/menus.js
@@ -28,6 +28,12 @@ function getSubMenuByLabel (menu, subMenuLabel) {
   return menu[0].submenu.items.filter(item => item.label === subMenuLabel)
 }
 
+function getCheckbox (menuLabel, subMenuLabel) {
+  var menu = getMenuByLabel(menuLabel)
+  var submenu = getSubMenuByLabel(menu, subMenuLabel)
+  return submenu[0].checked
+}
+
 function setCheckbox (menuLabel, subMenuLabel, value) {
   var menu = getMenuByLabel(menuLabel)
   var submenu = getSubMenuByLabel(menu, subMenuLabel)
@@ -37,5 +43,6 @@ function setCheckbox (menuLabel, subMenuLabel, value) {
 module.exports = {
   init,
   refresh,
+  getCheckbox,
   setCheckbox
 }

--- a/app/menus/menus/tools.js
+++ b/app/menus/menus/tools.js
@@ -1,3 +1,4 @@
+const {BrowserWindow} = require('electron')
 const windows = require('./../../windows')
 const camera = require('./../../camera')
 const recorder = require('./../../recorder')
@@ -82,9 +83,12 @@ module.exports = function () {
       accelerator: 'CmdOrCtrl+Alt+U',
       type: 'checkbox',
       checked: isRequestMobile,
+      enabled: !isFirstLoad,
       click (i, win) {
-        if (win == null) win = windows.getFocused()
-        win.rpc.emit('view:toggle-mobile')
+        BrowserWindow.getAllWindows().forEach((win) => {
+          // broadcast change accross all windows
+          try { win.rpc.emit('view:toggle-mobile') } catch (err) {}
+        })
       }
     }
   ]

--- a/app/menus/menus/tools.js
+++ b/app/menus/menus/tools.js
@@ -12,6 +12,9 @@ module.exports = function () {
   let hasConsole = false
   if (win !== null) hasConsole = win.hasConsole
 
+  let isRequestMobile = false
+  if (win !== null) isRequestMobile = win.isRequestMobile
+
   const submenu = [
     {
       label: 'Save Screenshot',
@@ -72,6 +75,16 @@ module.exports = function () {
       click (i, win) {
         if (win == null) win = windows.getFocused()
         win.rpc.emit('view:toggle-devtools')
+      }
+    },
+    {
+      label: 'Request Mobile Site',
+      accelerator: 'CmdOrCtrl+Alt+U',
+      type: 'checkbox',
+      checked: isRequestMobile,
+      click (i, win) {
+        if (win == null) win = windows.getFocused()
+        win.rpc.emit('view:toggle-mobile')
       }
     }
   ]

--- a/app/windows.js
+++ b/app/windows.js
@@ -61,7 +61,7 @@ function create (url, target) {
     darkTheme: true,
     webPreferences: {
     },
-    fullscreenable: !config.getPreference('picture_in_picture')
+    fullscreenable: !config.getPreference('picture_in_picture'),
   }
 
   const win = new BrowserWindow(browserOptions)
@@ -76,6 +76,7 @@ function create (url, target) {
   win.darkTheme = true
   win.hasTitleBar = config.getPreference('show_title_bar')
   win.hasConsole = false
+  win.isRequestMobile = config.getPreference('request_mobile_site')
 
   win.loadURL(path.join('file://', __dirname, '/window.html'))
 
@@ -108,6 +109,11 @@ function create (url, target) {
     win.setTitle(e)
   })
 
+  rpc.on('view:toggle-mobile-updated', (e) => {
+    win.isRequestMobile = e
+    menus.refresh()
+  })
+
   win.once('ready-to-show', () => {
     win.show()
     if (url) {
@@ -117,6 +123,10 @@ function create (url, target) {
       })
     }
   })
+
+  if (process.env.NODE_ENV !== 'production') {
+    win.webContents.openDevTools()
+  }
 }
 
 function broadcast (data) {

--- a/app/windows.js
+++ b/app/windows.js
@@ -61,7 +61,7 @@ function create (url, target) {
     darkTheme: true,
     webPreferences: {
     },
-    fullscreenable: !config.getPreference('picture_in_picture'),
+    fullscreenable: !config.getPreference('picture_in_picture')
   }
 
   const win = new BrowserWindow(browserOptions)

--- a/app/windows.js
+++ b/app/windows.js
@@ -124,7 +124,7 @@ function create (url, target) {
     }
   })
 
-  if (process.env.NODE_ENV !== 'production') {
+  if (isDev()) {
     win.webContents.openDevTools()
   }
 }
@@ -201,6 +201,10 @@ function resize (width, height) {
 
 function getFocused () {
   return focused
+}
+
+function isDev () {
+  return process.defaultApp || /[\\/]electron-prebuilt[\\/]/.test(process.execPath)
 }
 
 module.exports = {

--- a/app/windows.js
+++ b/app/windows.js
@@ -76,7 +76,7 @@ function create (url, target) {
   win.darkTheme = true
   win.hasTitleBar = config.getPreference('show_title_bar')
   win.hasConsole = false
-  win.isRequestMobile = config.getPreference('request_mobile_site')
+  win.isRequestMobile = config.getPreference('request_mobile_site') || menus.getCheckbox('Tools', 'Request Mobile Site')
 
   win.loadURL(path.join('file://', __dirname, '/window.html'))
 
@@ -110,7 +110,10 @@ function create (url, target) {
   })
 
   rpc.on('view:toggle-mobile-updated', (e) => {
-    win.isRequestMobile = e
+    // win.isRequestMobile = e
+    for (let win of windows) {
+      win.isRequestMobile = e
+    }
     menus.refresh()
   })
 

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -13,7 +13,7 @@ let frame = null
 let isFirstLoad = true
 let requestMobileSiteActive = false
 let userAgentDefault = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Oryoki/0.2.1 Chrome/58.0.3029.110 Electron/1.7.9 Safari/537.36'
-let userAgentMobile = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E233 Safari/601.1'
+let userAgentMobile = 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A356 Safari/604.1'
 let zoomIndex = 6
 const zoomIncrements = [
   25 / 100,

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -217,7 +217,7 @@ function toggleRequestMobile () {
   webview.setUserAgent(userAgentActive)
   webview.setAttribute('useragent', requestMobileSiteActive)
   rpc.emit('view:toggle-mobile-updated', requestMobileSiteActive)
-  load(webview.getURL())
+  reload()
 }
 
 function onCrashed (e) {

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -206,9 +206,9 @@ function toggleFilter (filter) {
 }
 
 // use this when updating the app to get the most recent UA
-function getDefaultUserAgent () {
-  console.log(webview.getUserAgent())
-}
+// function getDefaultUserAgent () {
+//   console.log(webview.getUserAgent())
+// }
 
 function toggleRequestMobile () {
   const userAgentActive = requestMobileSiteActive ? userAgentDefault : userAgentMobile

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -43,7 +43,7 @@ function init () {
   webview.setAttribute('plugins', 'plugins')
   webview.setAttribute('preload', './dist/preload.js')
 
-  if (config.getPreference('request_mobile_site')) {
+  if (config.getPreference('request_mobile_site') || menus.getCheckbox('Tools', 'Request Mobile Site')) {
     webview.setAttribute('useragent', userAgentMobile)
     requestMobileSiteActive = true
   }

--- a/lib/components/view.js
+++ b/lib/components/view.js
@@ -11,6 +11,9 @@ let frame = null
 
 // utils
 let isFirstLoad = true
+let requestMobileSiteActive = false
+let userAgentDefault = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Oryoki/0.2.1 Chrome/58.0.3029.110 Electron/1.7.9 Safari/537.36'
+let userAgentMobile = 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13E233 Safari/601.1'
 let zoomIndex = 6
 const zoomIncrements = [
   25 / 100,
@@ -39,6 +42,11 @@ function init () {
   webview.setAttribute('webPreferences', JSON.stringify(webPreferences))
   webview.setAttribute('plugins', 'plugins')
   webview.setAttribute('preload', './dist/preload.js')
+
+  if (config.getPreference('request_mobile_site')) {
+    webview.setAttribute('useragent', userAgentMobile)
+    requestMobileSiteActive = true
+  }
 
   console.log('[view] ✔')
   attachEvents()
@@ -91,6 +99,7 @@ function attachEvents () {
   rpc.on('view:zoom-out', zoomOut)
   rpc.on('view:reset-zoom', resetZoom)
   rpc.on('view:filter', toggleFilter)
+  rpc.on('view:toggle-mobile', toggleRequestMobile)
   rpc.on('view:toggle-devtools', () => {
     console.log(webview)
     if (webview.isDevToolsOpened()) webview.closeDevTools()
@@ -194,6 +203,21 @@ function toggleFilter (filter) {
     // invert handle color them as well
     rpc.emit('theme:toggle')
   }
+}
+
+// use this when updating the app to get the most recent UA
+function getDefaultUserAgent () {
+  console.log(webview.getUserAgent())
+}
+
+function toggleRequestMobile () {
+  const userAgentActive = requestMobileSiteActive ? userAgentDefault : userAgentMobile
+  requestMobileSiteActive = !requestMobileSiteActive
+  webview.getWebContents().session.setUserAgent(userAgentActive)
+  webview.setUserAgent(userAgentActive)
+  webview.setAttribute('useragent', requestMobileSiteActive)
+  rpc.emit('view:toggle-mobile-updated', requestMobileSiteActive)
+  load(webview.getURL())
 }
 
 function onCrashed (e) {


### PR DESCRIPTION
That was pretty easy. This creates the ability to set the useragent (UA) to load mobile sites. It does so by updating the `webview`’s `useragent`. For a good example navigate to Twitter, The New York Times, Google or Github.

A few things to note:

## Preferences

Updated the preferences with a new one called `request_mobile_site`, which defaults to `false`. There is also a menu item toggle under **Tools** called _Request Mobile Site_. The shortcut is `CmdOrCtrl+Alt+U`, as `M` was taken. `U` for useragent? Not the clearest… Toggling this option updates the UA and reloads the site to reflect the change.

## UA Storage

We must store the mobile/desktop useragents. I couldn’t quickly find a way of requesting the default Electron UA. The webview must be mounted to the DOM before you can request it’s current UA. To get around this, I define the UA through `setAttribute`, as [suggested here](https://github.com/electron/electron/issues/7218#issuecomment-247373154) to avoid first load without the correct UA defined, effectively overwriting any requests for the current UA as a way of storing the default/desktop.

Default (desktop) is what my current machine reads:

```
 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_5) AppleWebKit/537.36 (KHTML, like Gecko) Oryoki/0.2.1 Chrome/58.0.3029.110 Electron/1.7.9 Safari/537.36'
```

Mobile is an iPhone running iOS 11 in Safari:

```
'Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A356 Safari/604.1'
```

This is probably fine for OSX releases, but we’ll want to find a better way of doing this if building for another OS.